### PR TITLE
Switch to version features instead of autodetection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ keywords = ["gdk", "gtk", "gnome", "GUI"]
 [lib]
 name = "gdk_pixbuf"
 
+[features]
+"2.28" = ["gdk-pixbuf-sys/2.28"]
+"2.30" = ["2.28", "gdk-pixbuf-sys/2.30"]
+"2.32" = ["2.30", "gdk-pixbuf-sys/2.32"]
+
 [dependencies]
 gdk-pixbuf-sys = { git = "https://github.com/gtk-rs/sys" }
 glib = { git = "https://github.com/gtk-rs/glib" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "gdk-pixbuf"
 version = "0.0.1"
 authors = ["The Gtk-rs Project Developers"]
 
-description = "Rust bindings for the GDK library"
-repository = "https://github.com/gtk-rs/gdk"
+description = "Rust bindings for the GDK-PixBuf library"
+repository = "https://github.com/gtk-rs/gdk-pixbuf"
 license = "MIT"
-homepage = "https://github.com/gtk-rs/gdk"
-documentation = "https://github.com/gtk-rs/gdk"
+homepage = "https://github.com/gtk-rs/gdk-pixbuf"
+documentation = "https://github.com/gtk-rs/gdk-pixbuf"
 
 readme = "README.md"
 
@@ -22,6 +22,12 @@ name = "gdk_pixbuf"
 "2.32" = ["2.30", "gdk-pixbuf-sys/2.32"]
 
 [dependencies]
-gdk-pixbuf-sys = { git = "https://github.com/gtk-rs/sys" }
-glib = { git = "https://github.com/gtk-rs/glib" }
-libc = "0.1"
+libc = "0.2"
+
+[dependencies.gdk-pixbuf-sys]
+git = "https://github.com/gtk-rs/gdk-pixbuf-sys"
+version = "0.3.0"
+
+[dependencies.glib]
+git = "https://github.com/gtk-rs/glib"
+version = "0.0.8"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -69,7 +69,7 @@ impl PixbufAnimation {
         }
     }
 
-    #[cfg(gdk_3_8)] // gdk-pixbuf 2.28
+    #[cfg(feature = "2.28")]
     pub fn new_from_resource(resource_path: &str) -> Result<PixbufAnimation, Error> {
         unsafe {
             let mut error = ptr::null_mut();


### PR DESCRIPTION
Implement the reinstatement of version features outlined in https://github.com/gtk-rs/gtk/issues/243.

- Installed library version detection no longer impacts conditional compilation.
- Each crate defaults to supporting a particular minimal upstream version.
- Higher (newer) versions need to be enabled via cargo features e.g. `--features 3.16`, `features = ["3.16"]`.
- The selected version is checked against `pkg-config` aborting the build if it's too high.
- The use of `pkg-config` can be overridden by setting `GTK_LIB_DIR` env variable, which translates into `-L $GTK_LIB_DIR` linker argument. No version checks are done in this case.

[breaking change]