### PR TITLE
Use futures-preview crates instead of futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ v2_36_8 = ["v2_36", "gdk-pixbuf-sys/v2_36_8"]
 dox = ["glib/dox", "gdk-pixbuf-sys/dox"]
 purge-lgpl-docs = ["gtk-rs-lgpl-docs"]
 embed-lgpl-docs = ["gtk-rs-lgpl-docs"]
-futures = ["futures-core", "send-cell", "glib/futures", "gio/futures"]
+futures = ["futures-core-preview", "send-cell", "glib/futures", "gio/futures"]
 
 [build-dependencies.gtk-rs-lgpl-docs]
 version = "0.1.3"
@@ -40,7 +40,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 [dependencies]
 libc = "0.2"
 send-cell = { version = "0.1", optional = true }
-futures-core = { version = "0.2", optional = true }
+futures-core-preview = { version = "0.2", optional = true }
 
 [dependencies.gdk-pixbuf-sys]
 version = "0.6.0"


### PR DESCRIPTION
The futures crates were janked from crates.io and renamed to
futures-preview for whatever reason.