### PR TITLE
GdkPixbuf::new return Option

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -50,6 +50,10 @@ status = "generate"
     #manual is_windows_utf8
     ignore = true
     [[object.function]]
+    name = "new"
+        [object.function.return]
+        nullable = true
+    [[object.function]]
     name = "new_from_file_at_size"
     #manual is_windows_utf8
     ignore = true

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,15 +2,12 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use std::mem;
 use std::path::Path;
 use std::ptr;
 use glib::{Error, TimeVal};
 use glib::object::IsA;
 use glib::translate::*;
 use ffi;
-use glib_ffi;
-use gobject_ffi;
 use super::Pixbuf;
 
 glib_wrapper! {

--- a/src/auto/pixbuf.rs
+++ b/src/auto/pixbuf.rs
@@ -32,7 +32,7 @@ glib_wrapper! {
 }
 
 impl Pixbuf {
-    pub fn new(colorspace: Colorspace, has_alpha: bool, bits_per_sample: i32, width: i32, height: i32) -> Pixbuf {
+    pub fn new(colorspace: Colorspace, has_alpha: bool, bits_per_sample: i32, width: i32, height: i32) -> Option<Pixbuf> {
         unsafe {
             from_glib_full(ffi::gdk_pixbuf_new(colorspace.to_glib(), has_alpha.to_glib(), bits_per_sample, width, height))
         }


### PR DESCRIPTION
Fix #96

Updating gir-files don't helps as gir don't trusts nullables (or think that constructor always return something).
gdk_pixbuf_copy and gdk_pixbuf_composite_color_simple already return Option<Pixbuf>

cc @GuillaumeGomez, @sdroege , @federicomenaquintero