### PR TITLE
Fix arithmetic overflow in Pixbuf::put_pixel

### DIFF
--- a/src/pixbuf.rs
+++ b/src/pixbuf.rs
@@ -34,8 +34,16 @@ impl Pixbuf {
         unsafe extern "C" fn destroy<T: AsMut<[u8]>>(_: *mut c_uchar, data: *mut c_void) {
             let _data: Box<T> = Box::from_raw(data as *mut T); // the data will be destroyed now
         }
-
+        assert!(width > 0);
+        assert!(height > 0);
+        assert!(row_stride > 0);
         assert!(bits_per_sample == 8);
+
+        let width = width as usize;
+        let height = height as usize;
+        let row_stride = row_stride as usize;
+        let bits_per_sample = bits_per_sample as usize;
+
         let n_channels = if has_alpha { 4 } else { 3 };
         let last_row_len = width * ((n_channels * bits_per_sample + 7) / 8);
 
@@ -52,10 +60,10 @@ impl Pixbuf {
                 ptr,
                 colorspace.to_glib(),
                 has_alpha.to_glib(),
-                bits_per_sample,
-                width,
-                height,
-                row_stride,
+                bits_per_sample as i32,
+                width as i32,
+                height as i32,
+                row_stride as i32,
                 Some(destroy::<T>),
                 Box::into_raw(data) as *mut _,
             ))
@@ -267,11 +275,13 @@ impl Pixbuf {
 
     pub fn put_pixel(&self, x: i32, y: i32, red: u8, green: u8, blue: u8, alpha: u8) {
         unsafe {
-            let n_channels = self.get_n_channels();
+            let x = x as usize;
+            let y = y as usize;
+            let n_channels = self.get_n_channels() as usize;
             assert!(n_channels == 3 || n_channels == 4);
-            let rowstride = self.get_rowstride();
+            let rowstride = self.get_rowstride() as usize;
             let pixels = self.get_pixels();
-            let pos = (y * rowstride + x * n_channels) as usize;
+            let pos = y * rowstride + x * n_channels;
 
             pixels[pos] = red;
             pixels[pos + 1] = green;

--- a/src/pixbuf.rs
+++ b/src/pixbuf.rs
@@ -34,10 +34,13 @@ impl Pixbuf {
         unsafe extern "C" fn destroy<T: AsMut<[u8]>>(_: *mut c_uchar, data: *mut c_void) {
             let _data: Box<T> = Box::from_raw(data as *mut T); // the data will be destroyed now
         }
-        assert!(width > 0);
-        assert!(height > 0);
-        assert!(row_stride > 0);
-        assert!(bits_per_sample == 8);
+        assert!(width > 0, "width must be greater than 0");
+        assert!(height > 0, "height must be greater than 0");
+        assert!(row_stride > 0, "row_stride must be greater than 0");
+        assert!(
+            bits_per_sample == 8,
+            "bits_per_sample == 8 is the only supported value"
+        );
 
         let width = width as usize;
         let height = height as usize;
@@ -51,7 +54,10 @@ impl Pixbuf {
 
         let ptr = {
             let data: &mut [u8] = (*data).as_mut();
-            assert!(data.len() == ((height - 1) * row_stride + last_row_len) as usize);
+            assert!(
+                data.len() >= ((height - 1) * row_stride + last_row_len) as usize,
+                "data.len() must fit the width, height, and row_stride"
+            );
             data.as_mut_ptr()
         };
 
@@ -273,7 +279,16 @@ impl Pixbuf {
         slice::from_raw_parts_mut(ptr, len as usize)
     }
 
-    pub fn put_pixel(&self, x: i32, y: i32, red: u8, green: u8, blue: u8, alpha: u8) {
+    pub fn put_pixel(&self, x: u32, y: u32, red: u8, green: u8, blue: u8, alpha: u8) {
+        assert!(
+            x < self.get_width() as u32,
+            "x must be less than the pixbuf's width"
+        );
+        assert!(
+            y < self.get_height() as u32,
+            "y must be less than the pixbuf's height"
+        );
+
         unsafe {
             let x = x as usize;
             let y = y as usize;

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -39,3 +39,51 @@ fn new_from_mut_slice_doesnt_overflow() {
     let _pixbuf =
         Pixbuf::new_from_mut_slice(data, Colorspace::Rgb, true, 8, 21000, 29700, 21000 * 4);
 }
+
+#[test]
+#[should_panic]
+fn put_pixel_out_of_bounds_x_should_panic() {
+    let pixbuf = Pixbuf::new(Colorspace::Rgb, true, 8, 100, 200).unwrap();
+
+    pixbuf.put_pixel(100, 0, 0, 0, 0, 0);
+}
+
+#[test]
+#[should_panic]
+fn put_pixel_out_of_bounds_y_should_panic() {
+    let pixbuf = Pixbuf::new(Colorspace::Rgb, true, 8, 100, 200).unwrap();
+
+    pixbuf.put_pixel(0, 200, 0, 0, 0, 0);
+}
+
+#[test]
+#[should_panic]
+fn too_small_slice_should_panic() {
+    let data = vec![0u8; 100 * 99 * 4];
+
+    Pixbuf::new_from_mut_slice(data, Colorspace::Rgb, true, 8, 100, 100, 100 * 4);
+}
+
+#[test]
+fn last_row_with_incomplete_rowstride_works() {
+    // 1-pixel wide, RGB, 3 32-bit rows, no extra padding byte on the fourth row
+    let data = vec![0u8; 1 * 4 * 3 + 3];
+
+    Pixbuf::new_from_mut_slice(data, Colorspace::Rgb, false, 8, 1, 4, 4);
+}
+
+#[test]
+fn last_row_with_full_rowstride_works() {
+    // 1-pixel wide, RGB, 4 32-bit rows
+    let data = vec![0u8; 1 * 4 * 4];
+
+    Pixbuf::new_from_mut_slice(data, Colorspace::Rgb, false, 8, 1, 4, 4);
+}
+
+#[test]
+fn extra_data_after_last_row_works() {
+    // 1-pixel wide, RGB, 4 32-bit rows, plus some extra space
+    let data = vec![0u8; 1 * 4 * 4 + 42];
+
+    Pixbuf::new_from_mut_slice(data, Colorspace::Rgb, false, 8, 1, 4, 4);
+}

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -1,0 +1,41 @@
+extern crate gdk_pixbuf;
+use gdk_pixbuf::*;
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn put_pixel_doesnt_overflow() {
+    // Only test this on 64-bit boxes; otherwise we can't even
+    // allocate a pixbuf this big.
+
+    let pixbuf = Pixbuf::new(Colorspace::Rgb, true, 8, 21000, 29700).unwrap();
+
+    // debug build:  thread 'put_pixel_doesnt_overflow' panicked at
+    // 'attempt to multiply with overflow', src/pixbuf.rs:274:24
+    //
+    // release build: thread 'put_pixel_doesnt_overflow' panicked at
+    // 'index out of bounds: the len is 2494800000 but the index is
+    // 18446744071598664320', src/pixbuf.rs:276:13
+
+    pixbuf.put_pixel(20000, 26000, 255, 255, 255, 255);
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn new_from_mut_slice_doesnt_overflow() {
+    // Only test this on 64-bit boxes; otherwise we can't even
+    // allocate a pixbuf this big.
+
+    // Plus 5 to test that new_from_mut_slice() can ignore trailing data past the last row
+    let data = vec![0u8; 21000 * 4 * 29700 + 5];
+
+    // debug build: thread 'new_from_mut_slice_doesnt_overflow'
+    // panicked at 'attempt to multiply with overflow',
+    // /home/federico/src/gtk-rs/gdk-pixbuf/src/pixbuf.rs:50:36
+    //
+    // release build: thread 'new_from_mut_slice_doesnt_overflow'
+    // panicked at 'assertion failed: data.len() == ((height - 1) *
+    // row_stride + last_row_len) as usize', src/pixbuf.rs:50:13
+
+    let _pixbuf =
+        Pixbuf::new_from_mut_slice(data, Colorspace::Rgb, true, 8, 21000, 29700, 21000 * 4);
+}


### PR DESCRIPTION
This came from https://gitlab.gnome.org/GNOME/librsvg/-/issues/584.

Calling Pixbuf::put_pixel on a large pixbuf can lead to arithmetic
overflow.  The fix is to promote all i32 values to usize as soon as
possible.

Fixes https://github.com/gtk-rs/gdk-pixbuf/issues/147