### PR TITLE
Use glib_sys::GTimeVal instead of glib::TimeVal

### DIFF
--- a/src/pixbuf_animation.rs
+++ b/src/pixbuf_animation.rs
@@ -4,7 +4,6 @@
 
 use glib::object::IsA;
 use glib::translate::*;
-use glib::TimeVal;
 use PixbufAnimation;
 use PixbufAnimationIter;
 
@@ -20,7 +19,7 @@ impl<T: IsA<PixbufAnimation>> PixbufAnimationExtManual for T {
             let diff = s
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .expect("failed to convert time");
-            TimeVal {
+            glib_sys::GTimeVal {
                 tv_sec: diff.as_secs() as _,
                 tv_usec: diff.subsec_micros() as _,
             }

--- a/src/pixbuf_animation_iter.rs
+++ b/src/pixbuf_animation_iter.rs
@@ -5,7 +5,6 @@
 use super::Pixbuf;
 use gdk_pixbuf_sys;
 use glib::translate::*;
-use glib::TimeVal;
 
 use std::time::SystemTime;
 
@@ -26,7 +25,7 @@ impl PixbufAnimationIter {
         unsafe {
             from_glib(gdk_pixbuf_sys::gdk_pixbuf_animation_iter_advance(
                 self.to_glib_none().0,
-                &TimeVal {
+                &glib_sys::GTimeVal {
                     tv_sec: diff.as_secs() as _,
                     tv_usec: diff.subsec_micros() as _,
                 },


### PR DESCRIPTION
So that we can remove glib::TimeVal